### PR TITLE
The `/me` endpoint is marked as deprecated

### DIFF
--- a/TW-API.postman_collection.json
+++ b/TW-API.postman_collection.json
@@ -1587,33 +1587,6 @@
 			"name": "user",
 			"item": [
 				{
-					"name": "GET /me",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{TOKEN}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{host}}/v1/me",
-							"host": [
-								"{{host}}"
-							],
-							"path": [
-								"v1",
-								"me"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "POST /v1/user/signup/registration_code",
 					"request": {
 						"method": "POST",


### PR DESCRIPTION
The `/me` endpoint is marked as deprecated in our API.
Since this is the case we need to stop advertising it externally.