### PR TITLE
PLASTIC-17538: Remove encrypted-payload value

### DIFF
--- a/cards-api/Cards API Sandbox.postman_environment.json
+++ b/cards-api/Cards API Sandbox.postman_environment.json
@@ -73,9 +73,15 @@
 			"value": "",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "encrypted-card-data-payload",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-08-03T06:39:27.186Z",
-	"_postman_exported_using": "Postman/9.24.2"
+	"_postman_exported_at": "2022-08-16T03:20:41.797Z",
+	"_postman_exported_using": "Postman/9.26.6"
 }

--- a/cards-api/Cards API.postman_collection.json
+++ b/cards-api/Cards API.postman_collection.json
@@ -576,7 +576,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"keyVersion\":1,\"encryptedPayload\":\"eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMjU2R0NNIn0.cL-XnHk3-9yxt_r8bHk5mcr9zOt1srsJzUj-DczGTkUrQ09kF4AmyafL5vS8a0nYGClsfo2B0qHY6yivr98Un_hFiWNBcuecJNHwf-nh_6p9WukqQ-gMoJXtJUxwiAHcIR7fnLGYw1rJebQ1AQp8c2sdXRfEH4A3PaNqjlS2oBf-w3jyI0bZ_pDzz6yWE5oDWXHJDUWBMMdE0-vsJCO9s1s2ggVkdXkgJtdXtwaJjinaKxCsqHLzfECl0oU7kWyDHA6sl7C7aoWy700sKMngheNldlyGMZW6VxG4LGfXtJUXp2w0zuc66y0aB3R1diyvmxRvIwG9FK7BTbkQzU7H8Q.6QS9hxId4xcT1gsA..\"}"
+							"raw": "{\n    \"keyVersion\":1,\n    \"encryptedPayload\": {{encrypted-card-data-payload}}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{pci-host}}/twcard-data/v1/sensitive-card-data/details",


### PR DESCRIPTION
## Context

The Cards API Postman collection was containing an encrypted payload from a valid account. While the payload is expired, it's safer to remove it. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
