### PR TITLE
PLASTIC-18500: Add card transaction simulation

### DIFF
--- a/cards-api/Cards API Sandbox.postman_environment.json
+++ b/cards-api/Cards API Sandbox.postman_environment.json
@@ -33,6 +33,18 @@
 			"enabled": true
 		},
 		{
+			"key": "refresh_token",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "card_order_id",
 			"value": "",
 			"type": "default",
@@ -63,25 +75,25 @@
 			"enabled": true
 		},
 		{
-			"key": "refresh_token",
+			"key": "transaction-id",
 			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "x-tw-twcard-card-token",
-			"value": "",
+			"key": "dispute-reason",
+			"value": "wrong_amount",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "encrypted-card-data-payload",
+			"key": "pan",
 			"value": "",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-08-16T03:20:41.797Z",
-	"_postman_exported_using": "Postman/9.26.6"
+	"_postman_exported_at": "2022-11-03T08:43:57.905Z",
+	"_postman_exported_using": "Postman/10.0.38"
 }

--- a/cards-api/Cards API.postman_collection.json
+++ b/cards-api/Cards API.postman_collection.json
@@ -487,7 +487,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"cardLimitType\": \"LIFETIME\",\n    \"maxLimitAmount\": 100\n}",
+							"raw": "{\n    \"cardLimitType\": \"LIFETIME\",\n    \"maxLimitAmount\": 500\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -513,7 +513,46 @@
 					"response": []
 				},
 				{
-					"name": "6. Get card transactions",
+					"name": "6. Delete a lifetime limit",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/cards/{{card_token}}/spending-limits/lifetime",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"spending-limits",
+								"lifetime"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "7. Get card transactions",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -554,29 +593,33 @@
 			]
 		},
 		{
-			"name": "4. Sensitive Card Details",
+			"name": "4. Card transaction simulation",
 			"item": [
 				{
-					"name": "Get sensitive card details",
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
+					"name": "1. Preauthorisation",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
 					"request": {
-						"method": "GET",
+						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "x-tw-twcard-card-token",
-								"value": "{{x-tw-twcard-card-token}}",
+								"value": "Bearer {{token}}",
 								"type": "text"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"keyVersion\":1,\n    \"encryptedPayload\": {{encrypted-card-data-payload}}\n}",
+							"raw": "{\n    \"pos\": \"CHIP_AND_PIN\",\n    \"posTransactionStatus\": \"PREAUTH\",\n    \"amount\": {\n        \"value\": 2050.5,\n        \"currency\": \"AUD\"\n    },\n    \"acquirer\": {\n        \"institutionId\": \"430001\",\n        \"name\": \"Test get details\",\n        \"city\": \"Rouen\",\n        \"merchantCategoryCode\": 5999,\n        \"country\": \"FR\",\n        \"acceptorTerminalId\": \"TERMID01\",\n        \"acceptorIdCode\": \"CARD ACCEPTOR\",\n        \"forwardingInstitutionId\": \"400050\"\n    },\n    \"cardData\": {\n        \"pan\": \"{{pan}}\",\n        \"pin\": \"1234\",\n        \"cvv1\": \"123\",\n        \"icvv\": \"456\",\n        \"cvv2\": \"789\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -584,15 +627,239 @@
 							}
 						},
 						"url": {
-							"raw": "{{pci-host}}/twcard-data/v1/sensitive-card-data/details",
+							"raw": "https://api.sandbox.transferwise.tech/v1/simulation/spend/profiles/{{profile_id}}/cards/{{card_token}}/transactions/authorisation",
+							"protocol": "https",
 							"host": [
-								"{{pci-host}}"
+								"api",
+								"sandbox",
+								"transferwise",
+								"tech"
 							],
 							"path": [
-								"twcard-data",
 								"v1",
-								"sensitive-card-data",
-								"details"
+								"simulation",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"transactions",
+								"authorisation"
+							]
+						},
+						"description": "pos values:\nMINIMAL, CHIP_AND_PIN, CONTACTLESS_CARD, MAGNETIC_STRIPE, E_COMMERCE, MOBILE_WALLET"
+					},
+					"response": []
+				},
+				{
+					"name": "2a. Authorisation",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pos\": \"CHIP_AND_PIN\",\n    \"amount\": {\n        \"value\": 8.12,\n        \"currency\": \"EUR\"\n    },\n    \"acquirer\": {\n        \"institutionId\": \"430001\",\n        \"name\": \"Test payment\",\n        \"city\": \"Rouen\",\n        \"merchantCategoryCode\": 5999,\n        \"country\": \"FR\",\n        \"acceptorTerminalId\": \"TERMID01\",\n        \"acceptorIdCode\": \"CARD ACCEPTOR\",\n        \"forwardingInstitutionId\": \"400050\"\n    },\n    \"cardData\": {\n        \"pan\": \"{{pan}}\",\n        \"pin\": \"1234\",\n        \"cvv1\": \"123\",\n        \"icvv\": \"456\",\n        \"cvv2\": \"789\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.sandbox.transferwise.tech/v1/simulation/spend/profiles/{{profile_id}}/cards/{{card_token}}/transactions/authorisation",
+							"protocol": "https",
+							"host": [
+								"api",
+								"sandbox",
+								"transferwise",
+								"tech"
+							],
+							"path": [
+								"v1",
+								"simulation",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"transactions",
+								"authorisation"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "2b. Authorisation - ATM Withdrawal",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pos\": \"CHIP_AND_PIN\",\n    \"transactionType\": \"CASH_WITHDRAWAL\",\n    \"amount\": {\n        \"value\": 1002.80,\n        \"currency\": \"EUR\"\n    },\n    \"acquirer\": {\n        \"institutionId\": \"430001\",\n        \"name\": \"Test ATM withdrawal\",\n        \"city\": \"Rouen\",\n        \"merchantCategoryCode\": 5999,\n        \"country\": \"FR\",\n        \"acceptorTerminalId\": \"TERMID01\",\n        \"acceptorIdCode\": \"CARD ACCEPTOR\",\n        \"forwardingInstitutionId\": \"400050\"\n    },\n    \"cardData\": {\n        \"pan\": \"{{pan}}\",\n        \"pin\": \"1234\",\n        \"cvv1\": \"123\",\n        \"icvv\": \"456\",\n        \"cvv2\": \"789\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.sandbox.transferwise.tech/v1/simulation/spend/profiles/{{profile_id}}/cards/{{card_token}}/transactions/authorisation",
+							"protocol": "https",
+							"host": [
+								"api",
+								"sandbox",
+								"transferwise",
+								"tech"
+							],
+							"path": [
+								"v1",
+								"simulation",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"transactions",
+								"authorisation"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "5. Dispute",
+			"item": [
+				{
+					"name": "1. Get dispute reasons",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/dispute-form/reasons",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"dispute-form",
+								"reasons"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "2. Get dispute dynamic forms",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\": \"abc@def.com\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/dispute-form/flows/step/visa/{{dispute-reason}}?transactionId={{transaction-id}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"dispute-form",
+								"flows",
+								"step",
+								"visa",
+								"{{dispute-reason}}"
+							],
+							"query": [
+								{
+									"key": "transactionId",
+									"value": "{{transaction-id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "3. Create dispute",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"form\": {\n    \"agreedDetails\": {\n      \"agreed\": \"true\"\n    },\n    \"charged\": {\n      \"value\": 8,\n      \"currency\": \"EUR\"\n    },\n    \"expected\": {\n      \"value\": 5,\n      \"currency\": \"EUR\"\n    },\n    \"goods\": \"A book\",\n    \"details\": \"I've not received the book.\"\n  },\n  \"transaction\": {\n    \"transactionId\": \"{{transaction-id}}\",\n    \"amount\": \"50.5 AUD\",\n    \"mcc\": \"5999\",\n    \"status\": \"PENDING\",\n    \"merchantName\": \"Amazon\",\n    \"email\": \"abc@def.com\"\n  }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/dispute-form/flows/visa/{{dispute-reason}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"dispute-form",
+								"flows",
+								"visa",
+								"{{dispute-reason}}"
 							]
 						}
 					},


### PR DESCRIPTION
## Context

Adding the card transaction simulation and dispute API endpoints to the Cards API Postman collection.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
