### PR TITLE
add get and update spending permission endpoints to cards api

### DIFF
--- a/cards-api/Cards API.postman_collection.json
+++ b/cards-api/Cards API.postman_collection.json
@@ -654,6 +654,71 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "10. Get card spending permissions",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/cards/{{card_token}}/spending-permissions",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"spending-permissions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "11. Enable or disable card spending permission",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"type\": \"ATM_WITHDRAWAL\",\n    \"isEnabled\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/v3/spend/profiles/{{profile_id}}/cards/{{card_token}}/spending-permissions",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"v3",
+								"spend",
+								"profiles",
+								"{{profile_id}}",
+								"cards",
+								"{{card_token}}",
+								"spending-permissions"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
## Context

https://transferwise.atlassian.net/browse/PLASTIC-20114

Added the following endpoints to Cards API:

- get card spending permissions
- enable or disable card spending permission

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
