### PR TITLE
PLASTIC-21433: Add contact email API endpoints

### DIFF
--- a/bank-flow/TransferWise For Banks (Sandbox).postman_environment.json
+++ b/bank-flow/TransferWise For Banks (Sandbox).postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "6e009b2d-7c01-4960-b692-546ff0d02602",
+	"id": "3f54078a-4891-4173-b001-a686b7cab414",
 	"name": "TransferWise For Banks (Sandbox)",
 	"values": [
 		{
@@ -66,9 +66,15 @@
 			"key": "new-transfer-id",
 			"value": "",
 			"enabled": true
+		},
+		{
+			"key": "user-id",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-06-20T16:55:57.680Z",
-	"_postman_exported_using": "Postman/7.1.1"
+	"_postman_exported_at": "2023-04-11T03:26:28.243Z",
+	"_postman_exported_using": "Postman/10.12.11"
 }

--- a/bank-flow/TransferWise for Banks API flow.postman_collection.json
+++ b/bank-flow/TransferWise for Banks API flow.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "8037e96a-0aca-4431-8abe-8c9433de32f4",
+		"_postman_id": "4823d6bc-add2-4fcd-8cc7-4ac46713368b",
 		"name": "TransferWise for Banks API",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6154545"
 	},
 	"item": [
 		{
@@ -17,7 +18,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "28005757-b360-4336-85e2-27a04985eada",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.access_token) postman.setEnvironmentVariable(\"client-credentials-token\", jsonData.access_token);",
@@ -124,7 +124,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "5197a6aa-d210-4a59-ad98-f77aee360f4f",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.access_token) postman.setEnvironmentVariable(\"token\", jsonData.access_token);",
@@ -207,13 +206,97 @@
 								"description": "Request access token for created user"
 							},
 							"response": []
+						},
+						{
+							"name": "4a. Set contact email (for dummy emails)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"email\": \"new-user@email.com\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{host}}/v1/users/{{user-id}}/contact-email",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"v1",
+										"users",
+										"{{user-id}}",
+										"contact-email"
+									]
+								},
+								"description": "Request access token for created user"
+							},
+							"response": []
+						},
+						{
+							"name": "4b. Get contact email (for dummy emails)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{host}}/v1/users/{{user-id}}/contact-email",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"v1",
+										"users",
+										"{{user-id}}",
+										"contact-email"
+									]
+								},
+								"description": "Request access token for created user"
+							},
+							"response": []
 						}
 					],
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "9c3db8c4-040b-49b0-b190-134734fea3a2",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -223,16 +306,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "505623e0-a843-444e-9e31-35dbd9e3d0eb",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "1b. Access Existing User",
@@ -243,7 +323,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "05441564-ba8f-4c2e-abc8-76521c004196",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.access_token) postman.setEnvironmentVariable(\"token\", jsonData.access_token);",
@@ -325,9 +404,7 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "1c. Generate new token for returning user",
@@ -338,7 +415,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "d3979e81-52d8-4e3c-b232-260d891b1f7e",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.access_token) postman.setEnvironmentVariable(\"token\", jsonData.access_token);"
@@ -410,12 +486,9 @@
 							"response": []
 						}
 					],
-					"description": "After previosuly completing 1a or 1b you will have a refresh token stored, use this to generate new access tokens",
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					"description": "After previosuly completing 1a or 1b you will have a refresh token stored, use this to generate new access tokens"
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "2. Create user profile",
@@ -453,9 +526,7 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "2. Personal Profile",
@@ -466,7 +537,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "af37d058-6534-4025-b17d-58b55af0f533",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.id) postman.setEnvironmentVariable(\"personal-profile-id\", jsonData.id);"
@@ -633,7 +703,6 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "50e89bcb-1860-42ad-8346-aee0667557d2",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -643,16 +712,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1337c742-a1b9-4226-bc95-56ec81b35a06",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "3. Business Profile (Optional)",
@@ -663,7 +729,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "bc15ed0d-6426-41b0-8f7a-fd3fb4d0cf7b",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.id) postman.setEnvironmentVariable(\"business-profile-id\", jsonData.id);"
@@ -863,7 +928,6 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "3b852af2-2e40-4e52-9514-51b9395ebb01",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -873,19 +937,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3ba542fc-06ed-4f58-b1dd-27c2c49ef495",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "3. Transfer Flow",
@@ -899,7 +959,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "c7b7499e-fd8d-49d5-8feb-209a8065ba82",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.id) postman.setEnvironmentVariable(\"new-quote-id\", jsonData.id);"
@@ -942,7 +1001,6 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "e7ab2b8b-4cb7-4501-a1f8-fa6b56101df1",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -952,16 +1010,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "62b25a0f-d2be-4e2f-8a31-96d792283e19",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "2. Choose/create recipient",
@@ -1004,7 +1059,6 @@
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "eb73010d-8fb2-48b6-99a9-b0eb7cfdbec7",
 										"type": "text/javascript",
 										"exec": [
 											""
@@ -1014,16 +1068,13 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "c495867f-07b3-4c16-88f0-e1c8a547beef",
 										"type": "text/javascript",
 										"exec": [
 											""
 										]
 									}
 								}
-							],
-							"protocolProfileBehavior": {},
-							"_postman_isSubFolder": true
+							]
 						},
 						{
 							"name": "1b. Create new recipient account",
@@ -1098,7 +1149,6 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "70252a92-847d-4533-be52-22018a9e1dae",
 												"exec": [
 													"var jsonData = JSON.parse(responseBody);",
 													"if (jsonData.id) postman.setEnvironmentVariable(\"new-recipient-id\", jsonData.id);"
@@ -1166,7 +1216,6 @@
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "f7f271d1-8e30-4ffa-8f6a-096e8d1b5d6f",
 										"type": "text/javascript",
 										"exec": [
 											""
@@ -1176,23 +1225,19 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "8881f88c-6fc2-4fc6-b4de-48129de0c059",
 										"type": "text/javascript",
 										"exec": [
 											""
 										]
 									}
 								}
-							],
-							"protocolProfileBehavior": {},
-							"_postman_isSubFolder": true
+							]
 						}
 					],
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "e256b83c-bccb-41a7-a7d3-7fd5b0a1f0e5",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -1202,16 +1247,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4bc48a97-7a20-42da-95de-482a49f637e7",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "3. Create transfer",
@@ -1320,7 +1362,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "33595208-e842-4ab1-8ab7-229c968afebc",
 										"exec": [
 											"if (responseBody) postman.setEnvironmentVariable(\"idempotency-guid\", responseBody);"
 										],
@@ -1354,7 +1395,6 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "a81a5758-fca6-4b89-8441-123ad6dd5cb8",
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
 											"if (jsonData.id) postman.setEnvironmentVariable(\"new-transfer-id\", jsonData.id);"
@@ -1398,7 +1438,6 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "c096a28d-d6b0-46e7-8b05-80a5670b9680",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -1408,19 +1447,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7a9d3646-4f72-4189-adeb-a1d571eb8619",
 								"type": "text/javascript",
 								"exec": [
 									""
 								]
 							}
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "4. Fund transfer",
@@ -1460,12 +1495,9 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "5. Get updated transfer status",
@@ -1532,8 +1564,7 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "6. Webhooks subscription",
@@ -1544,7 +1575,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "28005757-b360-4336-85e2-27a04985eada",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"if (jsonData.access_token) postman.setEnvironmentVariable(\"client-credentials-token\", jsonData.access_token);",
@@ -1654,8 +1684,7 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "7. Transfer state simulation",
@@ -1790,8 +1819,7 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "8. Get transfer receipt",
@@ -1821,8 +1849,7 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		},
 		{
 			"name": "9. Update profile data",
@@ -1952,9 +1979,7 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "2. Business profile",
@@ -2115,13 +2140,9 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }


### PR DESCRIPTION
## Context

We've recently added the contact email API endpoints, which allow partners to set a contact email address for users who are using dummy email addresses. When set, the contact email address is used for notifications.

The Wiki page is here: https://transferwise.atlassian.net/wiki/spaces/plastic/pages/2706145770/Contact+s+email+address+for+dummy+emails.

This code change adds the contact email API endpoints to the Postman collection.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
